### PR TITLE
fix: use `wrap-ansi` for wrapping text when formatting tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -928,6 +928,12 @@
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
     },
+    "@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "chalk": "^4.1.0",
     "readline-transform": "^1.0.0",
     "strip-ansi": "^6.0.0",
+    "wrap-ansi": "^7.0.0",
     "yargs": "^16.0.3"
   },
   "devDependencies": {
@@ -56,6 +57,7 @@
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.25",
     "@types/readline-transform": "^1.0.0",
+    "@types/wrap-ansi": "^3.0.0",
     "@types/yargs": "^16.0.0",
     "@typescript-eslint/eslint-plugin": "^4.15.0",
     "@typescript-eslint/parser": "^4.15.0",

--- a/src/formatReport.ts
+++ b/src/formatReport.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import stripAnsi from 'strip-ansi';
+import wrapAnsi from 'wrap-ansi';
 import { AuditReport } from './generateReport';
 import { Finding, Severity, SeverityCounts } from './types';
 
@@ -34,15 +35,6 @@ const wordWithCount = (
 
 const countStr = (str: string): number => stripAnsi(str).length;
 const pad = (str: string): string => ` ${str.trim()} `;
-const wrap = (str: string, width: number): string[] => {
-  const regexp = new RegExp(
-    `.{1,${width}}(?:[\\s\u200B]+|$)|[^\\s\u200B]+?(?:[\\s\u200B]+|$)`,
-    'gu'
-  );
-
-  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-  return str.match(regexp) ?? [];
-};
 
 enum BoxChar {
   LightVertical = '│',
@@ -132,7 +124,9 @@ const buildTable = (
     maxLabelWidth,
     maxValueWidth,
     contents.reduce<string[]>((acc, [label, value], index) => {
-      const lines = wrap(pad(value), maxValueWidth);
+      const lines = wrapAnsi(value, maxValueWidth - 2, {
+        hard: true
+      }).split('\n');
 
       return acc.concat(
         [

--- a/test/src/formatReport.spec.ts
+++ b/test/src/formatReport.spec.ts
@@ -200,7 +200,7 @@ describe('formatReport', () => {
               '1234': buildFinding({
                 id: 1234,
                 paths: ['one'],
-                range: `>=1.0.${'0'.repeat(50)} < 1.5.0`,
+                range: `<1.2.3 || >2.0.0 < 2.2.1 || >=3.0.0 <3.0.1 || >= 4.0.0 <4.0.3`,
                 title: `The advisory with a very l${'o'.repeat(55)}ng name`
               })
             },
@@ -216,8 +216,39 @@ describe('formatReport', () => {
             ├──────────────────┼──────────────────────────────────────────────────────────────┤
             │ Package          │ yargs-parser                                                 │
             ├──────────────────┼──────────────────────────────────────────────────────────────┤
-            │ Vulnerable range │ >=1.0.00000000000000000000000000000000000000000000000000 <   │
-            │                  │ 1.5.0                                                        │
+            │ Vulnerable range │ <1.2.3 || >2.0.0 < 2.2.1 || >=3.0.0 <3.0.1 || >= 4.0.0       │
+            │                  │ <4.0.3                                                       │
+            ├──────────────────┼──────────────────────────────────────────────────────────────┤
+            │ More info        │ https://npmjs.com/advisories/1234                            │
+            └──────────────────┴──────────────────────────────────────────────────────────────┘
+            "
+          `);
+        });
+
+        it('wraps the value columns forcibly when required', () => {
+          const tables = formatReportAndGetTables({
+            findings: {
+              '1234': buildFinding({
+                id: 1234,
+                paths: ['one'],
+                range: `>=1.0.${'0'.repeat(100)} < 1.5.0`,
+                title: `The advisory with a very l${'o'.repeat(100)}ng name`
+              })
+            },
+            vulnerable: ['one']
+          });
+
+          expect(prettifyTables(tables)).toMatchInlineSnapshot(`
+            "
+            ┌──────────────────┬──────────────────────────────────────────────────────────────┐
+            │ low              │ The advisory with a very                                     │
+            │                  │ looooooooooooooooooooooooooooooooooooooooooooooooooooooooooo │
+            │                  │ ooooooooooooooooooooooooooooooooooooooooong name (#1234)     │
+            ├──────────────────┼──────────────────────────────────────────────────────────────┤
+            │ Package          │ yargs-parser                                                 │
+            ├──────────────────┼──────────────────────────────────────────────────────────────┤
+            │ Vulnerable range │ >=1.0.000000000000000000000000000000000000000000000000000000 │
+            │                  │ 0000000000000000000000000000000000000000000000 < 1.5.0       │
             ├──────────────────┼──────────────────────────────────────────────────────────────┤
             │ More info        │ https://npmjs.com/advisories/1234                            │
             └──────────────────┴──────────────────────────────────────────────────────────────┘


### PR DESCRIPTION
Ensures that text is hard wrapped, and also catches some cases there
were not being wrapped (such as really long version ranges)