### PR TITLE
feat: improve npm v7 support by walking the dependency tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,24 @@ outputting the results in a form that makes it easy to triage advisories, and
 providing support for ignoring advisories to keep your CI passing without having
 to sacrifice security.
 
-# NPM 7 Support
+# NPM 7 workspaces
 
-There is initial support for `npm@7`, but it has meant the audit report output
-has been changed significantly due to the difference in information provided in
-the new version.
+Workspaces (which are new in `npm@7`) should be supported at about the same
+level as `npm audit` itself supports them; standard dependencies should be just
+fine, but there may be edge-cases with `file:` dependencies due to limitations
+in resolving the dependency tree for these types of dependencies which affect
+`npm` itself.
 
-In particular, it's now no longer possible to calculate the full dependency path
-to a vulnerability without making additional calls to `npm`. As such, currently
-the paths used for ignoring vulnerabilities with `npm@7` are made up solely of
-the advisory number followed by the name of the package the advisory is for.
+For `audit-app`, these edge-cases _should_ primarily manifest as some
+vulnerabilities technically being reported twice, which shouldn't prevent using
+`audit-app`.
 
-This may be improved in the future.
+If you have any other issues with workspaces, please let us know!
+
+Also note that if you have a `file:` dependency that has the same name as a
+published `npm` package (e.g. `debug`), `npm` will assume it is that published
+package and so mark it affected by any advisories that may exist for the
+dependencies version.
 
 # Getting Started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1150,6 +1150,12 @@
         "@types/node": "*"
       }
     },
+    "@types/semver": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.6.tgz",
+      "integrity": "sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
@@ -4444,7 +4450,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -5195,10 +5200,12 @@
       }
     },
     "semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-      "dev": true
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -5825,8 +5832,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "readline-transform": "^1.0.0",
+    "semver": "^7.0.0",
     "strip-ansi": "^6.0.0",
     "wrap-ansi": "^7.0.0",
     "yargs": "^16.0.3"
@@ -57,6 +58,7 @@
     "@types/jest": "^26.0.23",
     "@types/node": "^14.17.3",
     "@types/readline-transform": "^1.0.0",
+    "@types/semver": "^7.3.6",
     "@types/wrap-ansi": "^3.0.0",
     "@types/yargs": "^16.0.3",
     "@typescript-eslint/eslint-plugin": "^4.26.1",

--- a/src/determineVulnerablePackages.ts
+++ b/src/determineVulnerablePackages.ts
@@ -1,0 +1,205 @@
+import { promises as fs } from 'fs';
+import { satisfies } from 'semver';
+import {
+  Npm7Advisory,
+  NpmLockDependency,
+  NpmPackageLock,
+  PackageJson
+} from './types';
+
+type PathAndVersion = [path: string, version: string];
+
+interface NpmLockDependencyBeingLinked {
+  version: string;
+  requires?: Record<string, string>;
+  dependencies?: Record<string, NpmLockDependency>;
+  nodes?: Record<string, NpmLockDependencyBeingLinked>;
+  parent?: NpmLockDependencyBeingLinked;
+}
+
+interface NpmLockDependencyWithLinks {
+  version: string;
+  requires?: Record<string, string>;
+  dependencies?: Record<string, NpmLockDependency>;
+  nodes: Record<string, NpmLockDependencyWithLinks>;
+  parent: NpmLockDependencyWithLinks | PackageLockWithLinks;
+}
+
+interface NpmLockDependencyWithLinksAndPaths
+  extends NpmLockDependencyWithLinks {
+  paths?: PathAndVersion[];
+}
+
+interface PackageLockWithLinks {
+  version: string;
+  dependencies: Record<string, NpmLockDependencyWithLinks>;
+}
+
+/**
+ * Resolves the dependency's `name` to it's position on the dependency tree
+ */
+const resolveDependency = (
+  name: string,
+  parent: NpmLockDependencyBeingLinked
+): NpmLockDependencyBeingLinked => {
+  if (parent.dependencies && name in parent.dependencies) {
+    return parent.dependencies[name];
+  }
+
+  if (!parent.parent) {
+    throw new Error(
+      `Could not find parent dependency for ${name} - ensure your package-lock.json is valid and matches your package.json`
+    );
+  }
+
+  return resolveDependency(name, parent.parent);
+};
+
+/**
+ * Links the given `dependency` with the related packages in the dependency tree
+ */
+const linkDependency = (
+  dependency: NpmLockDependencyBeingLinked,
+  parent: NpmLockDependencyBeingLinked
+) => {
+  dependency.parent = parent;
+  dependency.nodes = {};
+
+  if (!dependency.requires) {
+    return; // nothing to do
+  }
+
+  for (const name of Object.keys(dependency.requires)) {
+    dependency.nodes[name] = resolveDependency(name, dependency);
+  }
+
+  if (dependency.dependencies) {
+    linkDependencies(dependency.dependencies, dependency);
+  }
+};
+
+/**
+ * Links the given `dependencies` with related packages in the dependency tree
+ */
+const linkDependencies = (
+  dependencies: Record<string, NpmLockDependencyBeingLinked>,
+  parent: NpmLockDependencyBeingLinked
+) => {
+  for (const dependency of Object.values(dependencies)) {
+    linkDependency(dependency, parent);
+  }
+};
+
+/**
+ * Links the given `lock` so that all the dependencies in its tree are linked
+ * to each other
+ */
+function linkLock(lock: NpmPackageLock): asserts lock is PackageLockWithLinks {
+  linkDependencies(lock.dependencies, lock);
+}
+
+const listTopLevelDependencies = (json: PackageJson): string[] => {
+  return Object.keys({
+    ...json.dependencies,
+    ...json.devDependencies,
+    ...json.optionalDependencies,
+    ...json.peerDependencies
+  });
+};
+
+const collectDependencyPaths = (
+  name: string,
+  dependency: NpmLockDependencyWithLinksAndPaths
+): PathAndVersion[] => {
+  if (dependency.paths) {
+    return dependency.paths;
+  }
+
+  dependency.paths = [[name, dependency.version]];
+
+  for (const node of Object.entries(dependency.nodes)) {
+    for (const [path, version] of collectDependencyPaths(...node)) {
+      dependency.paths.push([`${name}>${path}`, version]);
+    }
+  }
+
+  return dependency.paths;
+};
+
+const flattenLockToPaths = (
+  lock: PackageLockWithLinks,
+  json: PackageJson
+): PathAndVersion[] => {
+  return listTopLevelDependencies(json).reduce<PathAndVersion[]>((ps, name) => {
+    if (!(name in lock.dependencies)) {
+      throw new Error(
+        `Could not find top-level dependency ${name} - ensure your package-lock.json is valid and matches your package.json`
+      );
+    }
+
+    return ps.concat(collectDependencyPaths(name, lock.dependencies[name]));
+  }, []);
+};
+
+const readPackageJson = async (dir: string): Promise<PackageJson> => {
+  return JSON.parse(
+    await fs.readFile(`${dir}/package.json`, 'utf-8')
+  ) as PackageJson;
+};
+
+const readPackageLockJson = async (dir: string): Promise<NpmPackageLock> => {
+  return JSON.parse(
+    await fs.readFile(`${dir}/package-lock.json`, 'utf-8')
+  ) as NpmPackageLock;
+};
+
+const determinePackagePaths = async (dir: string) => {
+  const packageLock = await readPackageLockJson(dir);
+  const packageJson = await readPackageJson(dir);
+
+  linkLock(packageLock);
+
+  return flattenLockToPaths(packageLock, packageJson);
+};
+
+const isVulnerable = (
+  advisory: Npm7Advisory,
+  [path, version]: PathAndVersion
+): boolean => {
+  return (
+    (path === advisory.name || path.endsWith(`>${advisory.name}`)) &&
+    satisfies(version, advisory.range)
+  );
+};
+
+const mapPathsToAdvisories = (
+  packagePaths: PathAndVersion[],
+  advisories: Npm7Advisory[]
+): Record<number, PathAndVersion[]> => {
+  const results: Record<number, PathAndVersion[]> = {};
+
+  for (const advisory of advisories) {
+    results[advisory.source] = packagePaths.filter(info =>
+      isVulnerable(advisory, info)
+    );
+  }
+
+  return results;
+};
+
+/**
+ * Determines which packages are vulnerable to the given advisories by walking
+ * the dependency tree laid out by the `package.json` & `package-lock.json` at
+ * the given `dir` and comparing the name & version of each package to the name
+ * and range described in each advisory.
+ *
+ * @return map of advisories to the packages that they impact
+ */
+export const determineVulnerablePackages = async (
+  advisories: Npm7Advisory[],
+  dir: string
+): Promise<Record<number, PathAndVersion[]>> => {
+  const packagePaths = await determinePackagePaths(dir);
+
+  return mapPathsToAdvisories(packagePaths, advisories);
+};

--- a/src/processNpm7AuditOutput.ts
+++ b/src/processNpm7AuditOutput.ts
@@ -1,0 +1,91 @@
+import { AuditResults, toMapOfFindings } from './audit';
+import { determineVulnerablePackages } from './determineVulnerablePackages';
+import {
+  Finding,
+  Npm7Advisory,
+  Npm7AuditMetadata,
+  Npm7AuditOutput,
+  Npm7Vulnerability,
+  Statistics
+} from './types';
+
+type DependencyStatistics = Statistics['dependencies'];
+
+/**
+ * Extracts the dependency statistics from the auditing metadata provided by
+ * `npm` v7
+ */
+const extractDependencyStatistics = (
+  metadata: Npm7AuditMetadata
+): DependencyStatistics => ({
+  dependencies: metadata.dependencies.prod,
+  devDependencies: metadata.dependencies.dev,
+  optionalDependencies: metadata.dependencies.optional,
+  totalDependencies: metadata.dependencies.total
+});
+
+/**
+ * Builds a `finding` from an `npm` v7 `advisory`
+ */
+const buildFinding = (
+  advisory: Npm7Advisory,
+  paths: string[],
+  versions: string[]
+): Finding => ({
+  id: advisory.source,
+  name: advisory.name,
+  paths,
+  versions,
+  range: advisory.range,
+  severity: advisory.severity,
+  title: advisory.title,
+  url: advisory.url
+});
+
+/**
+ * Finds all the advisories that are included with the given record of
+ * `vulnerabilities` provided by the audit output of `npm` v7.
+ */
+const findAdvisories = (
+  vulnerabilities: Record<string, Npm7Vulnerability>
+): Npm7Advisory[] => {
+  return Object.values(vulnerabilities)
+    .reduce<Array<Npm7Advisory | string>>((all, { via }) => all.concat(via), [])
+    .filter((via): via is Npm7Advisory => typeof via === 'object');
+};
+
+const transpose = (
+  arr: Array<[a: string, b: string]>
+): [a: string[], b: string[]] => {
+  const result: [a: string[], b: string[]] = [[], []];
+
+  for (const [a, b] of arr) {
+    result[0].push(a);
+    result[1].push(b);
+  }
+
+  return result;
+};
+
+/**
+ * Processes the given audit output provided by the `audit` command of `npm` v7,
+ * normalizing it into audit results.
+ */
+export const processNpm7AuditOutput = async (
+  auditOutput: Npm7AuditOutput,
+  dir: string
+): Promise<AuditResults> => {
+  const advisories = findAdvisories(auditOutput.vulnerabilities);
+  const vulnerablePackages = await determineVulnerablePackages(advisories, dir);
+
+  return {
+    findings: toMapOfFindings(
+      advisories.map(via => {
+        const [paths, versions] = transpose(vulnerablePackages[via.source]);
+
+        return buildFinding(via, paths, versions);
+      })
+    ),
+    dependencyStatistics: extractDependencyStatistics(auditOutput.metadata)
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,3 +151,23 @@ export interface Npm7AuditMetadata {
   vulnerabilities: SeverityCountsWithTotal;
   dependencies: DependencyCounts;
 }
+
+export interface PackageJson {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}
+
+export interface NpmLockDependency {
+  version: string;
+  requires?: Record<string, string>;
+  dependencies?: Record<string, NpmLockDependency>;
+}
+
+export interface NpmPackageLock {
+  version: string;
+  dependencies: Record<string, NpmLockDependency>;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,6 +159,7 @@ export interface PackageJson {
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  workspaces?: string[];
 }
 
 export interface NpmLockDependency {

--- a/test/src/determineVulnerablePackages.spec.ts
+++ b/test/src/determineVulnerablePackages.spec.ts
@@ -1,0 +1,548 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { determineVulnerablePackages } from '../../src/determineVulnerablePackages';
+import { Npm7Advisory, NpmPackageLock, PackageJson } from '../../src/types';
+
+const pullIntoMemoryFS = async (filename: string) => {
+  const actualFS = jest.requireActual<typeof import('fs')>('fs').promises;
+
+  await fs.writeFile(filename, await actualFS.readFile(filename));
+};
+
+const loadFixture = async (name: string) => {
+  const fixturePath = path.join(__dirname, '..', 'fixtures', name);
+
+  await fs.mkdir(fixturePath, { recursive: true });
+  await pullIntoMemoryFS(path.join(fixturePath, 'package.json'));
+  await pullIntoMemoryFS(path.join(fixturePath, 'package-lock.json'));
+
+  return fixturePath;
+};
+
+const writeJsonFile = async <TContents>(
+  dir: string,
+  filename: string,
+  contents: TContents
+) => {
+  await fs.writeFile(
+    path.join(dir, filename),
+    JSON.stringify(contents, null, 2)
+  );
+};
+
+const writePackageJsonAndLock = async (
+  dir: string,
+  json: PackageJson,
+  dependencies: NpmPackageLock['dependencies']
+) => {
+  await fs.mkdir(dir, { recursive: true });
+
+  await writeJsonFile<PackageJson>(dir, 'package.json', json);
+  await writeJsonFile<NpmPackageLock>(dir, 'package-lock.json', {
+    version: '1.0.0',
+    dependencies
+  });
+};
+
+const advisory: Npm7Advisory = {
+  dependency: '',
+  name: '',
+  range: '*', // match all by default
+  severity: 'high',
+  source: 1,
+  title: '',
+  url: ''
+} as const;
+
+describe('determineVulnerablePackages', () => {
+  beforeEach(async () => {
+    await fs.mkdir('my-dir', { recursive: true });
+  });
+
+  describe('when there is no package.json', () => {
+    beforeEach(async () => {
+      await writeJsonFile<NpmPackageLock>('my-dir', 'package-lock.json', {
+        version: '1.0.0',
+        dependencies: {}
+      });
+    });
+
+    it('throws an error', async () => {
+      await expect(determineVulnerablePackages([], 'my-dir')).rejects.toThrow(
+        /no such file or directory.+'my-dir\/package\.json'/iu
+      );
+    });
+  });
+
+  describe('when there is no package-lock.json', () => {
+    beforeEach(async () => {
+      await writeJsonFile<PackageJson>('my-dir', 'package.json', {});
+    });
+
+    it('throws an error', async () => {
+      await expect(determineVulnerablePackages([], 'my-dir')).rejects.toThrow(
+        /no such file or directory.+'my-dir\/package-lock\.json'/iu
+      );
+    });
+  });
+
+  describe('when the package-lock.json is missing a dependency', () => {
+    beforeEach(async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        { dependencies: { a: '^1.0.0' } },
+        {
+          a: { version: '1.0.0', requires: { b: '^1.0.0' } }
+        }
+      );
+    });
+
+    it('throws an error', async () => {
+      await expect(determineVulnerablePackages([], 'my-dir')).rejects.toThrow(
+        /Could not find parent dependency for b/iu
+      );
+    });
+  });
+
+  describe('when the package-lock.json is empty', () => {
+    beforeEach(async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        { dependencies: { a: '^1.0.0' } },
+        {}
+      );
+    });
+
+    it('throws an error', async () => {
+      await expect(determineVulnerablePackages([], 'my-dir')).rejects.toThrow(
+        /Could not find top-level dependency a/iu
+      );
+    });
+  });
+
+  describe('when there is a valid package.json and package-lock.json', () => {
+    describe('when there are no advisories', () => {
+      it('returns an empty object', async () => {
+        await writePackageJsonAndLock(
+          'my-dir',
+          { dependencies: { a: '^1.0.0' } },
+          {
+            a: { version: '1.0.0', requires: { b: '^1.0.0' } },
+            b: { version: '1.0.0', requires: { c: '^1.0.0' } },
+            c: { version: '1.0.0', requires: { d: '^1.0.0' } },
+            d: { version: '1.0.0' }
+          }
+        );
+
+        await expect(
+          determineVulnerablePackages([], 'my-dir')
+        ).resolves.toStrictEqual({});
+      });
+    });
+
+    it('finds vulnerable top level packages', async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        { dependencies: { a: '^1.0.0' } },
+        {
+          a: { version: '1.0.0', requires: { b: '^1.0.0' } },
+          b: { version: '1.0.0' }
+        }
+      );
+
+      await expect(
+        determineVulnerablePackages([{ ...advisory, name: 'a' }], 'my-dir')
+      ).resolves.toStrictEqual({ 1: [['a', '1.0.0']] });
+    });
+
+    it('finds vulnerable nested packages', async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        { dependencies: { a: '1' } },
+        {
+          a: { version: '1.0.0', requires: { b: '^1.0.0' } },
+          b: { version: '1.0.0' }
+        }
+      );
+
+      await expect(
+        determineVulnerablePackages([{ ...advisory, name: 'b' }], 'my-dir')
+      ).resolves.toStrictEqual({ 1: [['a>b', '1.0.0']] });
+    });
+
+    it('finds multiple nested vulnerable packages', async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        { dependencies: { a: '^1.0.0' } },
+        {
+          a: {
+            version: '1.0.0',
+            requires: { b: '^1.0.0', c: '^1.0.0', d: '^1.0.0' }
+          },
+          b: { version: '1.0.0' },
+          c: { version: '1.0.0' },
+          d: { version: '1.0.0' }
+        }
+      );
+
+      await expect(
+        determineVulnerablePackages(
+          [
+            { ...advisory, name: 'b', source: 1 },
+            { ...advisory, name: 'c', source: 2 },
+            { ...advisory, name: 'd', source: 3 }
+          ],
+          'my-dir'
+        )
+      ).resolves.toStrictEqual({
+        1: [['a>b', '1.0.0']],
+        2: [['a>c', '1.0.0']],
+        3: [['a>d', '1.0.0']]
+      });
+    });
+
+    it('finds vulnerable dependencies that also have vulnerable dependencies', async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        { dependencies: { a: '^1.0.0' } },
+        {
+          a: { version: '1.0.0', requires: { b: '^1.0.0' } },
+          b: { version: '1.0.0', requires: { c: '^1.0.0' } },
+          c: { version: '1.0.0', requires: { d: '^1.0.0' } },
+          d: { version: '1.0.0' }
+        }
+      );
+
+      await expect(
+        determineVulnerablePackages(
+          [
+            { ...advisory, name: 'b', source: 1 },
+            { ...advisory, name: 'd', source: 2 }
+          ],
+          'my-dir'
+        )
+      ).resolves.toStrictEqual({
+        1: [['a>b', '1.0.0']],
+        2: [['a>b>c>d', '1.0.0']]
+      });
+    });
+
+    it('supports nested trees with mid-level deduplication', async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        {
+          dependencies: {
+            'has-flag': '^5.0.0',
+            'supports-color': '^9.0.1',
+            'supports-hyperlinks': '^2.2.0'
+          }
+        },
+        {
+          'has-flag': { version: '5.0.0' },
+          'supports-color': {
+            version: '9.0.1',
+            requires: { 'has-flag': '^5.0.0' }
+          },
+          'supports-hyperlinks': {
+            version: '2.2.0',
+            requires: {
+              'has-flag': '^4.0.0',
+              'supports-color': '^7.0.0'
+            },
+            dependencies: {
+              'has-flag': { version: '4.0.0' },
+              'supports-color': {
+                version: '7.2.0',
+                requires: { 'has-flag': '^4.0.0' }
+              }
+            }
+          }
+        }
+      );
+
+      // We have 'has-flag' and 'supports-color' as dependencies along with v2 of
+      // 'supports-hyperlinks', which also requires 'has-flag' and 'supports-color'.
+      // Finally, 'supports-color' also requires 'has-flag'.
+      //
+      // The versions of 'has-flag' & 'supports-color' specified by us are not
+      // compatible with the versions required by 'supports-hyperlinks', so they
+      // must be nested within 'supports-hyperlinks' on the tree (since our direct
+      // dependencies have to placed at the top of the tree).
+      //
+      // The version of `has-flag` specified by `supports-hyperlinks` & the version
+      // of `supports-color` that it requires is compatible with both packages.
+      //
+      // This means that we only need *two* instances of `has-flag` in the tree,
+      // with the second version sitting "next" to the nested `supports-color`,
+      // and that that version is *not* the same version as the `has-flag` instance
+      // that sits at the top level of the dependency tree
+      await expect(
+        determineVulnerablePackages(
+          [{ ...advisory, name: 'has-flag' }],
+          'my-dir'
+        )
+      ).resolves.toStrictEqual({
+        1: [
+          ['has-flag', '5.0.0'],
+          ['supports-color>has-flag', '5.0.0'],
+          ['supports-hyperlinks>has-flag', '4.0.0'],
+          ['supports-hyperlinks>supports-color>has-flag', '4.0.0']
+        ]
+      });
+    });
+
+    it('supports aliases', async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        { dependencies: { myp: 'npm:mkdirp@^0.5.0' } },
+        {
+          minimist: { version: '0.0.8' },
+          myp: {
+            version: 'npm:mkdirp@0.5.0',
+            requires: { minimist: '0.0.8' }
+          }
+        }
+      );
+
+      await expect(
+        determineVulnerablePackages(
+          [
+            {
+              source: 1179,
+              name: 'minimist',
+              dependency: 'minimist',
+              title: 'Prototype Pollution',
+              url: 'https://npmjs.com/advisories/1179',
+              severity: 'low',
+              range: '<0.2.1 || >=1.0.0 <1.2.3'
+            }
+          ],
+          'my-dir'
+        )
+      ).resolves.toStrictEqual({
+        1179: [['myp>minimist', '0.0.8']]
+      });
+    });
+
+    it('supports different types of dependencies', async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        {
+          optionalDependencies: { a: '^1.0.0' },
+          peerDependencies: { c: '^1.0.0' }
+        },
+        {
+          a: {
+            version: '1.0.0',
+            requires: { b: '^1.0.0', c: '^1.0.0', d: '^1.0.0' }
+          },
+          b: { version: '1.0.0' },
+          c: { version: '1.0.0' },
+          d: { version: '1.0.0' }
+        }
+      );
+
+      await expect(
+        determineVulnerablePackages(
+          [
+            { ...advisory, name: 'b', source: 1 },
+            { ...advisory, name: 'c', source: 2 },
+            { ...advisory, name: 'd', source: 3 }
+          ],
+          'my-dir'
+        )
+      ).resolves.toStrictEqual({
+        1: [['a>b', '1.0.0']],
+        2: [
+          ['a>c', '1.0.0'],
+          ['c', '1.0.0']
+        ],
+        3: [['a>d', '1.0.0']]
+      });
+    });
+
+    it('handles basic semver ranges', async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        {
+          dependencies: {
+            a: '^1.0.0',
+            c: '^1.0.0'
+          }
+        },
+        {
+          a: { version: '1.0.0', requires: { b: '^1.0.0' } },
+          b: { version: '1.0.4' },
+          c: {
+            version: '1.0.1',
+            requires: { b: '^2.0.0' },
+            dependencies: {
+              b: { version: '2.3.0' }
+            }
+          }
+        }
+      );
+
+      await expect(
+        determineVulnerablePackages(
+          [{ ...advisory, name: 'b', range: '^1.0.2' }],
+          'my-dir'
+        )
+      ).resolves.toStrictEqual({
+        1: [['a>b', '1.0.4']]
+      });
+    });
+
+    it('handles complex semver ranges', async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        {
+          dependencies: {
+            a: '^1.0.0',
+            c: '^1.0.0',
+            d: '^1.1.0',
+            e: '^2.0.0'
+          }
+        },
+        {
+          a: {
+            version: '1.0.0',
+            requires: { b: '^1.0.0' }
+          },
+          b: { version: '1.0.4' },
+          c: {
+            version: '1.0.1',
+            requires: { b: '^2.0.0' },
+            dependencies: {
+              b: { version: '2.3.0' }
+            }
+          },
+          d: {
+            version: '1.2.1',
+            requires: { b: '^2.0.0', c: '^1.0.0' },
+            dependencies: {
+              b: { version: '2.3.1' },
+              c: { version: '1.0.1', requires: { b: '^2.0.0' } }
+            }
+          },
+          e: {
+            version: '2.5.8',
+            requires: { b: '^3.0.0', c: '^2.0.4' },
+            dependencies: {
+              b: { version: '3.1.0' },
+              c: {
+                version: '2.0.5',
+                requires: { b: '^3.0.0' }
+              }
+            }
+          }
+        }
+      );
+
+      await expect(
+        determineVulnerablePackages(
+          [{ ...advisory, name: 'b', range: '<1.0.5 || >=2.0.0 <2.3.1' }],
+          'my-dir'
+        )
+      ).resolves.toStrictEqual({
+        1: [
+          ['a>b', '1.0.4'],
+          ['c>b', '2.3.0']
+        ]
+      });
+    });
+
+    it('handles different ranges for different dependencies', async () => {
+      await writePackageJsonAndLock(
+        'my-dir',
+        {
+          dependencies: {
+            a: '^1.0.0',
+            c: '^1.0.0',
+            d: '^1.1.0',
+            e: '^2.0.0'
+          }
+        },
+        {
+          a: {
+            version: '1.0.0',
+            requires: { b: '^1.0.0' }
+          },
+          b: { version: '1.0.4' },
+          c: {
+            version: '1.0.1',
+            requires: { b: '^2.0.0' },
+            dependencies: {
+              b: { version: '2.3.0' }
+            }
+          },
+          d: {
+            version: '1.2.1',
+            requires: { b: '^2.0.0', c: '^1.0.0' },
+            dependencies: {
+              b: { version: '2.3.1' },
+              c: { version: '1.0.1', requires: { b: '^2.0.0' } }
+            }
+          },
+          e: {
+            version: '2.5.8',
+            requires: { b: '^3.0.0', c: '^2.0.4' },
+            dependencies: {
+              b: { version: '3.1.0' },
+              c: {
+                version: '2.0.5',
+                requires: { b: '^3.0.0' }
+              }
+            }
+          }
+        }
+      );
+
+      await expect(
+        determineVulnerablePackages(
+          [
+            {
+              ...advisory,
+              source: 1,
+              name: 'b',
+              range: '<1.0.5 || >=2.0.0 <2.3.1'
+            },
+            { ...advisory, source: 2, name: 'c', range: '>= 2.0.0' },
+            { ...advisory, source: 3, name: 'e', range: '< 0.5.0' }
+          ],
+          'my-dir'
+        )
+      ).resolves.toStrictEqual({
+        1: [
+          ['a>b', '1.0.4'],
+          ['c>b', '2.3.0']
+        ],
+        2: [['e>c', '2.0.5']],
+        3: []
+      });
+    });
+  });
+
+  describe('e2e', () => {
+    it('has the expected output for the mkdirp fixture', async () => {
+      await expect(
+        determineVulnerablePackages(
+          [
+            {
+              source: 1179,
+              name: 'minimist',
+              dependency: 'minimist',
+              title: 'Prototype Pollution',
+              url: 'https://npmjs.com/advisories/1179',
+              severity: 'low',
+              range: '<0.2.1 || >=1.0.0 <1.2.3'
+            }
+          ],
+          await loadFixture('mkdirp')
+        )
+      ).resolves.toStrictEqual({
+        1179: [['mkdirp>minimist', '0.0.8']]
+      });
+    });
+  });
+});

--- a/test/src/processNpm7AuditOutput.spec.ts
+++ b/test/src/processNpm7AuditOutput.spec.ts
@@ -1,0 +1,120 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { processNpm7AuditOutput } from '../../src/processNpm7AuditOutput';
+import { Npm7AuditOutput } from '../../src/types';
+import fixtures from '../fixtures';
+
+type ParsedNpm7Fixture = Npm7AuditOutput;
+
+const pullIntoMemoryFS = async (filename: string) => {
+  const actualFS = jest.requireActual<typeof import('fs')>('fs').promises;
+
+  await fs.writeFile(filename, await actualFS.readFile(filename));
+};
+
+const loadNpmAuditFixture = async <TFixture extends keyof typeof fixtures>(
+  name: TFixture
+): Promise<[fixture: typeof fixtures[TFixture], path: string]> => {
+  const fixturePath = path.join(__dirname, '..', 'fixtures', name);
+
+  await fs.mkdir(fixturePath, { recursive: true });
+  await pullIntoMemoryFS(path.join(fixturePath, 'package.json'));
+  await pullIntoMemoryFS(path.join(fixturePath, 'package-lock.json'));
+
+  return [fixtures[name], fixturePath];
+};
+
+describe('processNpm7AuditResults', () => {
+  it('handles a single advisory affecting a child dependency', async () => {
+    const [fixture, pathToFixture] = await loadNpmAuditFixture('mkdirp');
+
+    const auditOutput = JSON.parse(fixture['npm@7']) as ParsedNpm7Fixture;
+    const results = await processNpm7AuditOutput(auditOutput, pathToFixture);
+
+    expect(results.findings).toStrictEqual({
+      1179: {
+        id: 1179,
+        name: 'minimist',
+        paths: ['mkdirp>minimist'],
+        versions: ['0.0.8'],
+        range: '<0.2.1 || >=1.0.0 <1.2.3',
+        severity: 'low',
+        title: 'Prototype Pollution',
+        url: 'https://npmjs.com/advisories/1179'
+      }
+    });
+    expect(results.dependencyStatistics).toStrictEqual({
+      dependencies: auditOutput.metadata.dependencies.prod,
+      devDependencies: auditOutput.metadata.dependencies.dev,
+      optionalDependencies: auditOutput.metadata.dependencies.optional,
+      totalDependencies: auditOutput.metadata.dependencies.total
+    });
+  });
+
+  it('handles a single advisory affecting a top-level and de-duplicated nested dependency', async () => {
+    const [fixture, pathToFixture] = await loadNpmAuditFixture(
+      'mkdirp_minimist'
+    );
+    const auditOutput = JSON.parse(fixture['npm@7']) as ParsedNpm7Fixture;
+    const results = await processNpm7AuditOutput(auditOutput, pathToFixture);
+
+    expect(results.findings).toStrictEqual({
+      1179: {
+        id: 1179,
+        name: 'minimist',
+        paths: ['mkdirp>minimist', 'minimist'],
+        versions: ['0.0.8', '0.0.8'],
+        range: '<0.2.1 || >=1.0.0 <1.2.3',
+        severity: 'low',
+        title: 'Prototype Pollution',
+        url: 'https://npmjs.com/advisories/1179'
+      }
+    });
+    expect(results.dependencyStatistics).toStrictEqual({
+      dependencies: auditOutput.metadata.dependencies.prod,
+      devDependencies: auditOutput.metadata.dependencies.dev,
+      optionalDependencies: auditOutput.metadata.dependencies.optional,
+      totalDependencies: auditOutput.metadata.dependencies.total
+    });
+  });
+
+  describe('when there are multiple vulnerabilities against the same package', () => {
+    it('includes them as separate findings', async () => {
+      const [fixture, pathToFixture] = await loadNpmAuditFixture(
+        'serialize-to-js'
+      );
+      const auditOutput = JSON.parse(fixture['npm@7']) as ParsedNpm7Fixture;
+      const results = await processNpm7AuditOutput(auditOutput, pathToFixture);
+
+      expect(results.findings).toStrictEqual({
+        1429: {
+          id: 1429,
+          name: 'serialize-to-js',
+          paths: ['serialize-to-js'],
+          versions: ['1.0.0'],
+          range: '<3.0.1',
+          severity: 'moderate',
+          title: 'Cross-Site Scripting',
+          url: 'https://npmjs.com/advisories/1429'
+        },
+        790: {
+          id: 790,
+          name: 'serialize-to-js',
+          paths: ['serialize-to-js'],
+          versions: ['1.0.0'],
+          range: '<2.0.0',
+          severity: 'high',
+          title: 'Denial of Service',
+          url: 'https://npmjs.com/advisories/790'
+        }
+      });
+
+      expect(results.dependencyStatistics).toStrictEqual({
+        dependencies: auditOutput.metadata.dependencies.prod,
+        devDependencies: auditOutput.metadata.dependencies.dev,
+        optionalDependencies: auditOutput.metadata.dependencies.optional,
+        totalDependencies: auditOutput.metadata.dependencies.total
+      });
+    });
+  });
+});


### PR DESCRIPTION
This restores full & proper support for `npm` v7, making audit output equivalent
to pre-v7 - specifically now when auditing with npm v7:

- Vulnerability paths are now full paths
- Versions of the packages that are vulnerable are now listed in table output

## The backstory:

<details>
<summary>
npm v7 changed the audit output to something like this
</summary>

```
{
  "auditReportVersion": 2,
  "vulnerabilities": {
    "minimist": {
      "name": "minimist",
      "severity": "low",
      "via": [
        {
          "source": 1179,
          "name": "minimist",
          "dependency": "minimist",
          "title": "Prototype Pollution",
          "url": "https://npmjs.com/advisories/1179",
          "severity": "low",
          "range": "<0.2.1 || >=1.0.0 <1.2.3"
        }
      ],
      "effects": ["mkdirp"],
      "range": "<0.2.1 || >=1.0.0 <1.2.3",
      "nodes": ["node_modules/minimist"],
      "fixAvailable": {
        "name": "mkdirp",
        "version": "0.5.5",
        "isSemVerMajor": false
      }
    },
    "mkdirp": {
      "name": "mkdirp",
      "severity": "low",
      "via": ["minimist"],
      "effects": [],
      "range": "0.4.1 - 0.5.1",
      "nodes": ["node_modules/mkdirp"],
      "fixAvailable": {
        "name": "mkdirp",
        "version": "0.5.5",
        "isSemVerMajor": false
      }
    }
  },
  "metadata": {
    "vulnerabilities": {
      "info": 0,
      "low": 2,
      "moderate": 0,
      "high": 0,
      "critical": 0,
      "total": 2
    },
    "dependencies": {
      "prod": 3,
      "dev": 0,
      "optional": 0,
      "peer": 0,
      "peerOptional": 0,
      "total": 2
    }
  }
}
```

</details>

Importantly, it no longer includes a list of the specific versions of vulnerable
packages it found in the tree, nor does it guarantee a complete and full
dependency path. As a result, the original short-term solution that was landed
to provide basic npm v7 support used only the vulnerable package name, meaning
ignores were no longer per vulnerability, but instead per advisory + package.

## The solution:

All of this information that we want is stored in the dependency tree that `npm`
uses to do its thing (it's actually pretty much most of the point of the tree),
so if we can get a complete representation of the tree, we can figure out the
versions & paths ourselves.

This is actually something `npm` already supports doing for us - it's the
`npm list` command. Even better, you can pass it specific package names +
constraints, and it'll give you the paths to only those named packages that
match the constraints:

```
npm lists 'make-dir@<=2' --json
```

<details>
<summary>output</summary>

```
❯ npm lists 'make-dir@<=2' --json
{
  "version": "0.0.0",
  "name": "pr-statistician-frontend",
  "dependencies": {
    "webpack": {
      "version": "4.46.0",
      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz",
      "dependencies": {
        "terser-webpack-plugin": {
          "version": "1.4.5",
          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
          "dependencies": {
            "find-cache-dir": {
              "version": "2.1.0",
              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
              "dependencies": {
                "make-dir": {
                  "version": "2.1.0",
                  "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz"
                }
              }
            }
          }
        }
      }
    }
  }
}
```

</details>

So originally I did a rough implementation for that: we'd call `npm audit`, and
if the results were v7's output, we'd then call `npm list <packages>`.

That worked great, except it turns out
[`npm list` requires `node_modules`](https://github.com/npm/cli/issues/3068),
because it uses the dependency tree that exists on disk (termed the "actual"
tree) - this meant we couldn't use it as a solution because

1. You'd have to be able to do a successful `npm i` which means systems like CIs
   would have to meet all external requirements like node versions and c-libs,
   and
2. It meant OS-specific dependencies (like `fsevents`) wouldn't be shown on the
   tree if your OS didn't match (since the dependency wouldn't be installed).

This wouldn't be an issue if we could have `npm list` use the _virtual_ tree,
which is what npm computes initially (and stores in the lockfile) in order to
then compute the _actual_ tree (aka, figure out how to write the virtual tree to
disk).

[So that's what I did](https://github.com/npm/cli/pull/3408).

_But_, while I was doing so, I kept thinking about how else we could get this,
because calling `npm list` adds some extra overhead plus I didn't know when my
PR would get landed & released (if at all) - and I realised something:

- the virtual dependency tree is stored in the `package-lock.json`
- this file is _required_ for `npm audit` to work (and has to be in sync with
  `package.json`)
- we need to know the path to the `package.json` & `package-lock.json` in order
  to do `npm audit`
- so, we should be able to read the `package.json` & `package-lock.json`
  ourselves without adding any extra requirements for using `audit-app` 🎉

Now, `npm` actually publish the component that is responsible for interacting
with and managing the dependency tree & `node_modules` as its own package for it
to be used on its own - it's called
[`arborist`](https://www.npmjs.com/package/@npmcli/arborist); in theory we could
use for this, but `arborist` provides a lot more than we need since it has to
support far more than just walking the dependency tree, so it's a very big
dependency to be using for just v7 lock-file support.

Fortunately, walking the virtual dependency tree is actually a relatively
straightforward task because the whole point is that it describes the tree
without external restrictions like supported OSs, de-duplications, engine
versions, etc - those only come into play when figuring out how to represent the
virtual tree in the current environment (aka, installing dependencies), which is
something `arborist` does.

This means I was able to write a lightweight tree walker that should be
comparable to `arborist`, without adding a lot of extra dependencies or size to
`audit-app`; this in turn allows us to calculate the missing information for
vulnerable packages when auditing v7 lock-files.

I've tested it against a number of repos and trees, with a number of variations
and weird trees, and so far it looks to be working fine - which thinking about
it makes sense: a lot of the weird edge-case stuff really is when you're
installing the dependencies to an actual file system.

The primary "edge-case" I've found so far is with the handling of `file:`
dependencies, which is mainly impactful because they're how `npm` 7 workspaces
operate. Specifically, it's not possible to accurately determine if a `file:`
dependency is a direct dependency or pulled in by another package or both or if
they're a workspace dependency.

The bottom line is that `file:` dependencies are treated as if they're direct
dependencies, in addition to the usual dependency tree pathing; in practice this
means if a package depends on a `file:` dependency which itself pulls in a
vulnerable package, then that vulnerable package will be counted twice: once for
the top-level package, and then again from the `file:` dependency.

I don't think this should create any big issues because:

- the paths are still correct, there's a few more
- `file:` dependencies are complex and weird anyway, with their own security
  cases - this is doubly so for packages depending on `file:` dependencies
- `npm`/`arborist` itself doesn't handle these any better, so there isn't really
  any alternatives anyway

---

This work has also highlighted that it would probably be best to refactor a
bunch of the code so that it's cleaner and better structured - specifically
about breaking out the auditing functions into their own grouped files based on
what they're actually doing.

I think the test layout could use a refactor to - ideally it'd be great to have
a proper e2e suite that could be run.

_However_, I've decided to get this PR landed first because I think it greatly
influences what a good layout would be, so refactoring first would just be doing
work that'd need refactoring very soon afterwards anyway.

Finally, I think there are some normalizing of the audit output that we should
do:

- remove `.>` prefix in paths from `pnpm`
- repeat the versions in npm v6 & `pnpm` output to be one-per-path (to match npm
  v7)
