### PR TITLE
feat: implement `--update-config-ignores` flag to make life easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ with no comments, trailing commas, or single-quotes:
 
 You can disable loading from a config file using `--no-config.`
 
+### `--update-config-ignores`
+
+Default: false
+
+If provided, `audit-app` will attempt to update the config file pointed to by
+`--config` to contain an `ignore` property made up of the vulnerabilities found
+during the audit.
+
 ## `--package-manager`, `-p`
 
 Default: `auto`  
@@ -281,6 +289,9 @@ track and update the list of ignored vulnerabilities:
   ]
 }
 ```
+
+You can have `audit-app` attempt to update the config for you with the
+`--update-config-ignores` flag.
 
 ## How it works
 

--- a/src/createOrUpdateConfig.ts
+++ b/src/createOrUpdateConfig.ts
@@ -1,0 +1,36 @@
+import { promises as fs } from 'fs';
+import { AuditReport } from './generateReport';
+import { Options } from './index';
+import { sortVulnerabilityPaths } from './sortVulnerabilityPaths';
+
+type RelevantConfigOptions = Pick<Options, 'ignore'>;
+
+const tryReadConfig = async (
+  configPath: string
+): Promise<RelevantConfigOptions> => {
+  try {
+    return JSON.parse(
+      await fs.readFile(configPath, 'utf-8')
+    ) as RelevantConfigOptions;
+  } catch {
+    return { ignore: [] };
+  }
+};
+
+export const createOrUpdateConfig = async (
+  configPath: string,
+  report: AuditReport
+): Promise<void> => {
+  const configContents = await tryReadConfig(configPath);
+
+  configContents.ignore = sortVulnerabilityPaths([
+    ...report.vulnerable,
+    ...report.ignored
+  ]);
+
+  await fs.writeFile(
+    configPath,
+    `${JSON.stringify(configContents, null, 2)}\n`,
+    'utf-8'
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { SupportedPackageManager, audit } from './audit';
+import { createOrUpdateConfig } from './createOrUpdateConfig';
 import { SupportedReportFormat, formatReport } from './formatReport';
 import { generateReport } from './generateReport';
 
@@ -8,6 +9,8 @@ export interface Options {
   debug: boolean;
   ignore: string[];
   output: SupportedReportFormat;
+  config: string;
+  updateConfigIgnores: boolean;
 }
 
 export const auditApp = async (options: Options): Promise<void> => {
@@ -22,6 +25,14 @@ export const auditApp = async (options: Options): Promise<void> => {
     process.exitCode = (report.vulnerable.length || report.missing.length) && 1;
 
     console.log(formatReport(options.output, report));
+
+    if (options.updateConfigIgnores && options.config) {
+      await createOrUpdateConfig(options.config, report);
+
+      console.warn(
+        `\nHave updated ${options.config} to ignore these vulnerabilities`
+      );
+    }
   } catch (error) {
     process.exitCode = 1;
 

--- a/src/parseArgs.ts
+++ b/src/parseArgs.ts
@@ -65,6 +65,10 @@ const parseWithConfig = (args: string[], configPath?: string): ParsedArgs => {
   const { argv }: ParsedArgvWithConfig = yargs(args)
     .completion('completion', false)
     .options({
+      updateConfigIgnores: {
+        boolean: true,
+        default: false
+      },
       config: {
         alias: 'c',
         string: true,

--- a/test/src/createOrUpdateConfig.spec.ts
+++ b/test/src/createOrUpdateConfig.spec.ts
@@ -1,0 +1,83 @@
+import { promises as fs } from 'fs';
+import { createOrUpdateConfig } from '../../src/createOrUpdateConfig';
+import { AuditReport } from '../../src/generateReport';
+
+const EmptyStatistics = {} as AuditReport['statistics'];
+
+const readConfig = async (configPath: string) => {
+  return JSON.parse(await fs.readFile(configPath, 'utf-8')) as unknown;
+};
+
+describe('createOrUpdateConfig', () => {
+  it('adds new vulnerabilities', async () => {
+    await createOrUpdateConfig('my-config.json', {
+      findings: {},
+      ignored: [],
+      missing: [],
+      statistics: EmptyStatistics,
+      vulnerable: ['1', '2', '3']
+    });
+
+    await expect(readConfig('my-config.json')).resolves.toHaveProperty(
+      'ignore',
+      ['1', '2', '3']
+    );
+  });
+
+  it('preserves existing ignores', async () => {
+    await createOrUpdateConfig('my-config.json', {
+      findings: {},
+      ignored: ['1', '2', '3'],
+      missing: [],
+      statistics: EmptyStatistics,
+      vulnerable: []
+    });
+
+    await expect(readConfig('my-config.json')).resolves.toHaveProperty(
+      'ignore',
+      ['1', '2', '3']
+    );
+  });
+
+  describe('when the config does not exist', () => {
+    it('creates it', async () => {
+      await createOrUpdateConfig('my-config.json', {
+        findings: {},
+        ignored: [],
+        missing: [],
+        statistics: EmptyStatistics,
+        vulnerable: ['1', '2', '3']
+      });
+
+      await expect(readConfig('my-config.json')).resolves.toHaveProperty(
+        'ignore',
+        ['1', '2', '3']
+      );
+    });
+  });
+
+  describe('when the config already exists', () => {
+    beforeEach(async () => {
+      await fs.writeFile(
+        'my-config.json',
+        JSON.stringify({ packageManager: 'npm' }),
+        'utf-8'
+      );
+    });
+
+    it('preserves existing properties', async () => {
+      await createOrUpdateConfig('my-config.json', {
+        findings: {},
+        ignored: [],
+        missing: [],
+        statistics: EmptyStatistics,
+        vulnerable: ['1', '2', '3']
+      });
+
+      await expect(readConfig('my-config.json')).resolves.toStrictEqual({
+        packageManager: 'npm',
+        ignore: ['1', '2', '3']
+      });
+    });
+  });
+});

--- a/test/src/index.spec.ts
+++ b/test/src/index.spec.ts
@@ -18,7 +18,9 @@ const emptyOptions: Options = {
   directory: process.cwd(),
   ignore: [],
   debug: false,
-  output: 'tables'
+  output: 'tables',
+  config: '.auditapprc.json',
+  updateConfigIgnores: false
 };
 
 describe('auditApp', () => {


### PR DESCRIPTION
Somewhat related to #19 - will make it easier to switch over to the new ignores, and another thing that's just been really painful.

This should be stable, but there might be some edge-cases - similar to #19, this is part of a holdover feature to make things easier until I think [`osv-detector`](https://github.com/G-Rath/osv-detector) is ready to replace this.