### PR TITLE
docs: add note about recommending `osv-detector`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # audit-app
 
+> While `audit-app` is not officially deprecated, we strongly recommend using
+> [`osv-detector`](https://github.com/G-Rath/osv-detector) instead - it does the
+> exact same thing, only better! (and faster too)
+
 A cli tool for auditing apps & packages using their respective package managers,
 outputting the results in a form that makes it easy to triage advisories, and
 providing support for ignoring advisories to keep your CI passing without having


### PR DESCRIPTION
I don't think anyone's really using this anymore but `osv-detector` is just flat out better in so many ways.

I am still planning to "maintain" this in so far as is needed, for the time being.